### PR TITLE
Decode Refactor

### DIFF
--- a/tests/framing.rs
+++ b/tests/framing.rs
@@ -194,7 +194,7 @@ mod tests {
         assert!(result.is_err());
         assert_eq!(
             result.unwrap_err().description(),
-            HDLCError::MissingFinalFend.description()
+            HDLCError::MissingFend.description()
         )
     }
 
@@ -336,7 +336,7 @@ mod tests {
         assert!(result.is_err());
         assert_eq!(
             result.unwrap_err().description(),
-            HDLCError::MissingFinalFend.description()
+            HDLCError::MissingFend.description()
         )
     }
 }


### PR DESCRIPTION
I rewrote the `decode` function. I personally think it is a bit easier to read, and it also runs faster than the previous implementation.