### PR TITLE
Added failure crate, improved FEND errors

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1,4 +1,146 @@
 [[package]]
+name = "backtrace"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "backtrace-sys 0.1.24 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cfg-if 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.43 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-demangle 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "backtrace-sys"
+version = "0.1.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "cc 1.0.20 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.43 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "cc"
+version = "1.0.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "cfg-if"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "failure"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "backtrace 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
+ "failure_derive 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "failure_derive"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "proc-macro2 0.4.13 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quote 0.6.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 0.14.9 (registry+https://github.com/rust-lang/crates.io-index)",
+ "synstructure 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "hdlc"
 version = "0.2.3"
+dependencies = [
+ "failure 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+]
 
+[[package]]
+name = "libc"
+version = "0.2.43"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "proc-macro2"
+version = "0.4.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "unicode-xid 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "quote"
+version = "0.6.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "proc-macro2 0.4.13 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "rustc-demangle"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "syn"
+version = "0.14.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "proc-macro2 0.4.13 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quote 0.6.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "unicode-xid 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "synstructure"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "proc-macro2 0.4.13 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quote 0.6.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 0.14.9 (registry+https://github.com/rust-lang/crates.io-index)",
+ "unicode-xid 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "unicode-xid"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "winapi"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "winapi-i686-pc-windows-gnu 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi-x86_64-pc-windows-gnu 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "winapi-i686-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "winapi-x86_64-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[metadata]
+"checksum backtrace 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)" = "89a47830402e9981c5c41223151efcced65a0510c13097c769cede7efb34782a"
+"checksum backtrace-sys 0.1.24 (registry+https://github.com/rust-lang/crates.io-index)" = "c66d56ac8dabd07f6aacdaf633f4b8262f5b3601a810a0dcddffd5c22c69daa0"
+"checksum cc 1.0.20 (registry+https://github.com/rust-lang/crates.io-index)" = "3cc738b39aea615873af94099619ed6915a82575880ed5cdfbf17b63307f1b14"
+"checksum cfg-if 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "0c4e7bb64a8ebb0d856483e1e682ea3422f883c5f5615a90d51a2c82fe87fdd3"
+"checksum failure 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7efb22686e4a466b1ec1a15c2898f91fa9cb340452496dca654032de20ff95b9"
+"checksum failure_derive 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "946d0e98a50d9831f5d589038d2ca7f8f455b1c21028c0db0e84116a12696426"
+"checksum libc 0.2.43 (registry+https://github.com/rust-lang/crates.io-index)" = "76e3a3ef172f1a0b9a9ff0dd1491ae5e6c948b94479a3021819ba7d860c8645d"
+"checksum proc-macro2 0.4.13 (registry+https://github.com/rust-lang/crates.io-index)" = "ee5697238f0d893c7f0ecc59c0999f18d2af85e424de441178bcacc9f9e6cf67"
+"checksum quote 0.6.8 (registry+https://github.com/rust-lang/crates.io-index)" = "dd636425967c33af890042c483632d33fa7a18f19ad1d7ea72e8998c6ef8dea5"
+"checksum rustc-demangle 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)" = "bcfe5b13211b4d78e5c2cadfebd7769197d95c639c35a50057eb4c05de811395"
+"checksum syn 0.14.9 (registry+https://github.com/rust-lang/crates.io-index)" = "261ae9ecaa397c42b960649561949d69311f08eeaea86a65696e6e46517cf741"
+"checksum synstructure 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)" = "85bb9b7550d063ea184027c9b8c20ac167cd36d3e06b3a40bceb9d746dc1a7b7"
+"checksum unicode-xid 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "fc72304796d0818e357ead4e000d19c9c174ab23dc11093ac919054d20a6a7fc"
+"checksum winapi 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)" = "773ef9dcc5f24b7d850d0ff101e542ff24c3b090a9768e03ff889fdef41f00fd"
+"checksum winapi-i686-pc-windows-gnu 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+"checksum winapi-x86_64-pc-windows-gnu 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,3 +8,6 @@ readme = "README.md"
 repository = "https://github.com/CLomanno/hdlc"
 documentation = "https://docs.rs/hdlc"
 license = "MIT OR Apache-2.0"
+
+[dependencies]
+failure = "0.1.2"

--- a/tests/framing.rs
+++ b/tests/framing.rs
@@ -42,18 +42,13 @@ mod tests {
 
     #[test]
     fn pack_rejects_dupe_s_chars() {
-        use std::error::Error;
-
         let chars = SpecialChars::new(0x7E, 0x7D, 0x5D, 0x5D);
         let msg: Vec<u8> = vec![0x01, chars.fend, 0x00, chars.fesc, 0x00, 0x05, 0x80, 0x09];
 
         let result = encode(&msg, chars);
 
         assert!(result.is_err());
-        assert_eq!(
-            result.unwrap_err().description(),
-            HDLCError::DuplicateSpecialChar.description()
-        )
+        assert_eq!(result.unwrap_err(), HDLCError::DuplicateSpecialChar)
     }
 
     #[test]
@@ -122,24 +117,17 @@ mod tests {
 
     #[test]
     fn depack_rejects_dupe_s_chars() {
-        use std::error::Error;
-
         let chars = SpecialChars::new(0x7E, 0x7D, 0x5D, 0x5D);
         let msg: Vec<u8> = vec![0x01, chars.fend, 0x00, chars.fesc, 0x00, 0x05, 0x80, 0x09];
 
         let result = decode(&msg, chars);
 
         assert!(result.is_err());
-        assert_eq!(
-            result.unwrap_err().description(),
-            HDLCError::DuplicateSpecialChar.description()
-        )
+        assert_eq!(result.unwrap_err(), HDLCError::DuplicateSpecialChar)
     }
 
     #[test]
     fn depack_rejects_stray_fend_char() {
-        use std::error::Error;
-
         let chars = SpecialChars::default();
         let msg: Vec<u8> = vec![
             chars.fend, 0x01, 0x00, 0x69, 0x00, 0x05, 0x80, 0x09, chars.fend, chars.fend,
@@ -148,16 +136,11 @@ mod tests {
         let result = decode(&msg, chars);
 
         assert!(result.is_err());
-        assert_eq!(
-            result.unwrap_err().description(),
-            HDLCError::FendCharInData.description()
-        )
+        assert_eq!(result.unwrap_err(), HDLCError::FendCharInData)
     }
 
     #[test]
     fn depack_rejects_stray_fesc_char() {
-        use std::error::Error;
-
         let chars = SpecialChars::default();
         let msg: Vec<u8> = vec![
             chars.fend, 0x01, chars.fesc, 0x00, chars.fesc, 0x00, 0x05, 0x80, 0x09, chars.fend,
@@ -166,16 +149,11 @@ mod tests {
         let result = decode(&msg, chars);
 
         assert!(result.is_err());
-        assert_eq!(
-            result.unwrap_err().description(),
-            HDLCError::MissingTradeChar.description()
-        )
+        assert_eq!(result.unwrap_err(), HDLCError::MissingTradeChar)
     }
 
     #[test]
     fn depack_rejects_incomplete_message() {
-        use std::error::Error;
-
         let chars = SpecialChars::default();
         let msg: Vec<u8> = vec![
             chars.fend,
@@ -192,10 +170,7 @@ mod tests {
         let result = decode(&msg, chars);
 
         assert!(result.is_err());
-        assert_eq!(
-            result.unwrap_err().description(),
-            HDLCError::MissingFend.description()
-        )
+        assert_eq!(result.unwrap_err(), HDLCError::MissingFinalFend)
     }
 
     #[test]
@@ -264,24 +239,17 @@ mod tests {
 
     #[test]
     fn depack_slice_rejects_dupe_s_chars() {
-        use std::error::Error;
-
         let chars = SpecialChars::new(0x7E, 0x7D, 0x5D, 0x5D);
         let mut msg = [0x01, chars.fend, 0x00, chars.fesc, 0x00, 0x05, 0x80, 0x09];
 
         let result = decode_slice(&mut msg, chars);
 
         assert!(result.is_err());
-        assert_eq!(
-            result.unwrap_err().description(),
-            HDLCError::DuplicateSpecialChar.description()
-        )
+        assert_eq!(result.unwrap_err(), HDLCError::DuplicateSpecialChar)
     }
 
     #[test]
     fn depack_slice_rejects_stray_fend_char() {
-        use std::error::Error;
-
         let chars = SpecialChars::default();
         let mut msg = [
             chars.fend, 0x01, 0x00, 0x69, 0x00, 0x05, 0x80, 0x09, chars.fend, chars.fend,
@@ -290,16 +258,11 @@ mod tests {
         let result = decode_slice(&mut msg, chars);
 
         assert!(result.is_err());
-        assert_eq!(
-            result.unwrap_err().description(),
-            HDLCError::FendCharInData.description()
-        )
+        assert_eq!(result.unwrap_err(), HDLCError::FendCharInData)
     }
 
     #[test]
     fn depack_slice_rejects_stray_fesc_char() {
-        use std::error::Error;
-
         let chars = SpecialChars::default();
         let mut msg = [
             chars.fend, 0x01, chars.fesc, 0x00, chars.fesc, 0x00, 0x05, 0x80, 0x09, chars.fend,
@@ -308,16 +271,11 @@ mod tests {
         let result = decode_slice(&mut msg, chars);
 
         assert!(result.is_err());
-        assert_eq!(
-            result.unwrap_err().description(),
-            HDLCError::MissingTradeChar.description()
-        )
+        assert_eq!(result.unwrap_err(), HDLCError::MissingTradeChar)
     }
 
     #[test]
     fn depack_slice_rejects_incomplete_message() {
-        use std::error::Error;
-
         let chars = SpecialChars::default();
         let mut msg = [
             chars.fend,
@@ -334,9 +292,6 @@ mod tests {
         let result = decode_slice(&mut msg, chars);
 
         assert!(result.is_err());
-        assert_eq!(
-            result.unwrap_err().description(),
-            HDLCError::MissingFend.description()
-        )
+        assert_eq!(result.unwrap_err(), HDLCError::MissingFinalFend)
     }
 }


### PR DESCRIPTION
Had HDLCError derive Fail using the failure crate. Split MissingFend error into MissingFirstFend and MissingFinalFend errors to provide more information.