### PR TITLE
Add a Frame reader 

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -184,7 +184,7 @@ dependencies = [
 
 [[package]]
 name = "hdlc"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "criterion",
  "thiserror",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "hdlc"
 edition = "2021"
-version = "0.3.0"
+version = "0.4.0"
 authors = ["Christopher Lomanno <Lomannoc@gmail.com>", "Oskar Østby <oskar@oestby.io>"]
 description = "Rust implementation of HDLC with support of the IEEE standard"
 keywords = ["hdlc", "frame", "framing", "byte-swap", "packetize"]


### PR DESCRIPTION
Add a `FrameReader` to read hdlc frames from a byte stream.

Takes a `std::io::Read` trait and allows the extraction of HDLC frames, which then can be decoded with `decode`