### PR TITLE
Allow sharing of FEND byte between consecutive frames

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -459,6 +459,9 @@ impl FrameReader<'_> {
                 if in_frame {
                     self.rest.clear();
                     full_frame = true;
+
+                    // Re-insert FEND so that we can handle sharing with following packet
+                    bytes_checked -= 1;
                     break;
                 } else {
                     // If the next byte is also a fend byte, skip it

--- a/tests/framing.rs
+++ b/tests/framing.rs
@@ -413,8 +413,12 @@ mod tests {
     fn get_multiple_frames() {
         let chars = SpecialChars::default();
         let msg = [
-            chars.fend, 0x01, 0x00, 0x05, 0x80, chars.fend, chars.fend, 0x02, 0x00, 0x05, 0x80,
-            chars.fend, chars.fend, 0x03, 0x00, 0x05, 0x80, chars.fend,
+            chars.fend, 0x01, 0x00, 0x05, 0x80, chars.fend,
+            chars.fend, 0x02, 0x00, 0x05, 0x80, chars.fend,
+            // Start-frame delimeter inferred from previous packet:
+            0x03, 0x00, 0x05, 0x80, chars.fend,
+            0x11, 0x13, 0x17, 0x1d, 0x1f, chars.fend,
+            chars.fend, 0x07, 0x0b, chars.fend
         ];
         let mut frames: Vec<Vec<u8>> = vec![];
         let mut reader = Cursor::new(msg);
@@ -429,10 +433,12 @@ mod tests {
                 }
             }
         }
-        assert_eq!(frames.len(), 3);
+        assert_eq!(frames.len(), 5);
         assert_eq!(frames[0], vec![126, 1, 0, 5, 128, 126]);
         assert_eq!(frames[1], vec![126, 2, 0, 5, 128, 126]);
         assert_eq!(frames[2], vec![126, 3, 0, 5, 128, 126]);
+        assert_eq!(frames[3], vec![126, 17, 19, 23, 29, 31, 126]);
+        assert_eq!(frames[4], vec![126, 7, 11, 126]);
     }
 
     #[test]


### PR DESCRIPTION
According to the [HDLC article in Wikipedia](https://en.wikipedia.org/wiki/High-Level_Data_Link_Control#Structure), it is allowable for the FEND (0x7e) byte to be shared between adjacent packets, rather than requiring a separate FEND at the end of one packet and another FEND immediately afterwards at the start of the next packet.

This small patch adjusts the behaviour of the `FrameReader` so that the FEND byte at the end of a frame is reinserted into the internal buffer. The existing unit-tests for the `FrameReader` have been adjusted to include a mix of frames delimited by double and single FEND bytes.